### PR TITLE
Allow custom root_dir for commands for deployments on symlinks

### DIFF
--- a/Command/StartScheduledWorkerCommand.php
+++ b/Command/StartScheduledWorkerCommand.php
@@ -65,6 +65,9 @@ class StartScheduledWorkerCommand extends ContainerAwareCommand
         $redisPort = $this->getContainer()->getParameter('resque.redis.port');
         $redisDatabase = $this->getContainer()->getParameter('resque.redis.database');
 
+        // Allow overriding of root_dir if deploying to a symlinked folder
+        $workdirectory = $this->getContainer()->getParameter('resque.worker.root_dir');
+
         if ($redisHost != NULL && $redisPort != NULL) {
             $env['REDIS_BACKEND'] = $redisHost . ':' . $redisPort;
         }
@@ -82,7 +85,8 @@ class StartScheduledWorkerCommand extends ContainerAwareCommand
             }
         }
 
-        $workerCommand = $phpExecutable . ' ' . __DIR__ . '/../bin/resque-scheduler';
+        $workdirectory = $workdirectory ? $workdirectory . '/vendor/resquebundle/resque/bin/' : __DIR__ . '/../bin/';
+        $workerCommand = $phpExecutable . ' ' . $workdirectory . 'resque-scheduler';
 
         if (!$input->getOption('foreground')) {
             $logFile = $this->getContainer()->getParameter(

--- a/Command/StartWorkerCommand.php
+++ b/Command/StartWorkerCommand.php
@@ -79,6 +79,9 @@ class StartWorkerCommand extends ContainerAwareCommand
         $redisPort = $this->getContainer()->getParameter('resque.redis.port');
         $redisDatabase = $this->getContainer()->getParameter('resque.redis.database');
 
+        // Allow overriding of root_dir if deploying to a symlinked folder
+        $workdirectory = $this->getContainer()->getParameter('resque.worker.root_dir');
+
         if ($redisHost != NULL && $redisPort != NULL) {
             $env['REDIS_BACKEND'] = $redisHost . ':' . $redisPort;
         }
@@ -104,7 +107,7 @@ class StartWorkerCommand extends ContainerAwareCommand
         $workerCommand = strtr('%php% %opt% %dir%/resque', [
             '%php%' => $phpExecutable,
             '%opt%' => $opt,
-            '%dir%' => __DIR__ . '/../bin',
+            '%dir%' => $workdirectory ? $workdirectory . '/vendor/resquebundle/resque/bin' : __DIR__ . '/../bin',
         ]);
 
         if (!$input->getOption('foreground')) {


### PR DESCRIPTION
This PR allows you to set the path to the symfony app root_dir in your configuration params - this is to overcome issues with deployments that are in symlink folders where __DIR__ resolves to the real folder and not the symlink