### PR TITLE
Adding the ability to specify the name for the log file when running StartWorkerCommand

### DIFF
--- a/Command/StartWorkerCommand.php
+++ b/Command/StartWorkerCommand.php
@@ -27,7 +27,7 @@ class StartWorkerCommand extends ContainerAwareCommand
             ->addOption('count', 'c', InputOption::VALUE_REQUIRED, 'How many workers to fork', 1)
             ->addOption('interval', 'i', InputOption::VALUE_REQUIRED, 'How often to check for new jobs across the queues', 5)
             ->addOption('foreground', 'f', InputOption::VALUE_NONE, 'Should the worker run in foreground')
-            ->addOption('memory-limit', 'm', InputOption::VALUE_REQUIRED, 'Force cli memory_limit (expressed in Mbytes)');
+            ->addOption('memory-limit', 'm', InputOption::VALUE_REQUIRED, 'Force cli memory_limit (expressed in Mbytes)')
             ->addOption('log-file', 'l', InputOption::VALUE_REQUIRED, 'Name of log file if not run in foreground');
     }
 

--- a/Command/StartWorkerCommand.php
+++ b/Command/StartWorkerCommand.php
@@ -28,6 +28,7 @@ class StartWorkerCommand extends ContainerAwareCommand
             ->addOption('interval', 'i', InputOption::VALUE_REQUIRED, 'How often to check for new jobs across the queues', 5)
             ->addOption('foreground', 'f', InputOption::VALUE_NONE, 'Should the worker run in foreground')
             ->addOption('memory-limit', 'm', InputOption::VALUE_REQUIRED, 'Force cli memory_limit (expressed in Mbytes)');
+            ->addOption('log-file', 'l', InputOption::VALUE_REQUIRED, 'Name of log file if not run in foreground');
     }
 
     /**
@@ -108,9 +109,11 @@ class StartWorkerCommand extends ContainerAwareCommand
         ]);
 
         if (!$input->getOption('foreground')) {
-            $workerCommand = strtr('nohup %cmd% > %logs_dir%/resque.log 2>&1 & echo $!', [
+            $logFile = $input->getOption('log-file') ?: 'resque.log';
+            $workerCommand = strtr('nohup %cmd% > %logs_dir%/%log_file% 2>&1 & echo $!', [
                 '%cmd%'      => $workerCommand,
                 '%logs_dir%' => $this->getContainer()->getParameter('kernel.logs_dir'),
+                '%log_file%' => $logFile,
             ]);
         }
 

--- a/Command/StartWorkerCommand.php
+++ b/Command/StartWorkerCommand.php
@@ -28,7 +28,7 @@ class StartWorkerCommand extends ContainerAwareCommand
             ->addOption('interval', 'i', InputOption::VALUE_REQUIRED, 'How often to check for new jobs across the queues', 5)
             ->addOption('foreground', 'f', InputOption::VALUE_NONE, 'Should the worker run in foreground')
             ->addOption('memory-limit', 'm', InputOption::VALUE_REQUIRED, 'Force cli memory_limit (expressed in Mbytes)')
-            ->addOption('log-file', 'l', InputOption::VALUE_REQUIRED, 'Name of log file in %logs_dir% to use if run in background', 'resque.log');
+            ->addOption('log-file', 'l', InputOption::VALUE_REQUIRED, 'Name of log file in kernel.logs_dir to use if run in background', 'resque.log');
     }
 
     /**

--- a/Command/StartWorkerCommand.php
+++ b/Command/StartWorkerCommand.php
@@ -28,7 +28,7 @@ class StartWorkerCommand extends ContainerAwareCommand
             ->addOption('interval', 'i', InputOption::VALUE_REQUIRED, 'How often to check for new jobs across the queues', 5)
             ->addOption('foreground', 'f', InputOption::VALUE_NONE, 'Should the worker run in foreground')
             ->addOption('memory-limit', 'm', InputOption::VALUE_REQUIRED, 'Force cli memory_limit (expressed in Mbytes)')
-            ->addOption('log-file', 'l', InputOption::VALUE_REQUIRED, 'Name of log file if not run in foreground');
+            ->addOption('log-file', 'l', InputOption::VALUE_REQUIRED, 'Name of log file in %logs_dir% to use if run in background', 'resque.log');
     }
 
     /**
@@ -109,11 +109,10 @@ class StartWorkerCommand extends ContainerAwareCommand
         ]);
 
         if (!$input->getOption('foreground')) {
-            $logFile = $input->getOption('log-file') ?: 'resque.log';
             $workerCommand = strtr('nohup %cmd% > %logs_dir%/%log_file% 2>&1 & echo $!', [
                 '%cmd%'      => $workerCommand,
                 '%logs_dir%' => $this->getContainer()->getParameter('kernel.logs_dir'),
-                '%log_file%' => $logFile,
+                '%log_file%' => $input->getOption('log-file'),
             ]);
         }
 


### PR DESCRIPTION
Hi

The name worker's log file when run in background is hardcoded to 'resque.log', if we run several workers all end up writing to the same file, this PR adds a flag `--log-file` to be able to specify a different file for each worker you launch.