### PR TITLE
Use vendor/autoload.php if app/autoload.php does not exist

### DIFF
--- a/bin/resque
+++ b/bin/resque
@@ -6,7 +6,18 @@ if (empty($QUEUE)) {
     die("Set QUEUE env var containing the list of queues to work.\n");
 }
 
-require __DIR__ . '/../../../../app/autoload.php';
+$autoloadFiles = [
+    __DIR__ . '/../../../../app/autoload.php',
+    __DIR__ . '/../../../../vendor/autoload.php',
+    __DIR__ . '/../vendor/autoload.php',
+];
+
+foreach ($autoloadFiles as $autoloadFile) {
+    if (file_exists($autoloadFile)) {
+        require $autoloadFile;
+        break;
+    }
+}
 
 $APP_INCLUDE = getenv('APP_INCLUDE');
 if ($APP_INCLUDE) {

--- a/bin/resque-scheduler
+++ b/bin/resque-scheduler
@@ -1,7 +1,18 @@
 #!/usr/bin/env php
 <?php
 
-require __DIR__ . '/../../../../app/autoload.php';
+$autoloadFiles = [
+    __DIR__ . '/../../../../app/autoload.php',
+    __DIR__ . '/../../../../vendor/autoload.php',
+    __DIR__ . '/../vendor/autoload.php',
+];
+
+foreach ($autoloadFiles as $autoloadFile) {
+    if (file_exists($autoloadFile)) {
+        require $autoloadFile;
+        break;
+    }
+}
 
 // Load the user's application if one exists
 $APP_INCLUDE = getenv('APP_INCLUDE');


### PR DESCRIPTION
As symfony 3.3 have removed `app/autoload.php` and just using `vendor/autoload.php` I made this little fix.

The last autoload file entry is so the bin files also can be tested by travis if needed.