### PR TITLE
Handle posix kill failures

### DIFF
--- a/Command/StopWorkerCommand.php
+++ b/Command/StopWorkerCommand.php
@@ -63,11 +63,16 @@ class StopWorkerCommand extends ContainerAwareCommand
 
             return 0;
         }
-        
+
         foreach ($workers as $worker) {
-            $output->writeln(\sprintf('Stopping %s...', $worker->getId()));
-            $worker->stop();
-            $worker->getWorker()->unregisterWorker();
+            if ($worker->stop()) {
+                // The worker was successfully killed.
+                $worker->getWorker()->unregisterWorker();
+                $output->writeln(\sprintf('Stopped %s', $worker->getId()));
+            }
+            else {
+                $output->writeln(\sprintf('<error>Failed to stop %s</error>', $worker->getId()));
+            }
         }
 
         return 0;

--- a/Worker.php
+++ b/Worker.php
@@ -29,7 +29,7 @@ class Worker
     {
         $parts = \explode(':', $this->getId());
 
-        return \posix_kill($parts[1], 3);
+        return \posix_kill($parts[1], SIGQUIT);
     }
 
     /**


### PR DESCRIPTION
This PR should handle the issue reported in #27 

We should not unregister workers if they have not been properly stopped. This could happen if workers are operating on multiple servers.