### PR TITLE
Add Symfony4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,35 @@
 language: php
 php:
+  - 5.6
   - 7.0
   - 7.1
+
 before_script:
-#  - phpenv config-rm xdebug.ini
   - composer install
+
+matrix:
+  fast_finish: true
+  include:
+    # test 2.8 LTS
+    - php: 5.6
+      env: SYMFONY_VERSION=2.8.*
+    # test the latest stable 3.x release
+    - php: 5.6
+      env: SYMFONY_VERSION=^3.0
+    # test the latest release (including beta releases)
+    - php: 7.1
+      env: DEPENDENCIES=beta
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+before_install:
+  - if [ "$DEPENDENCIES" = "beta" ]; then composer config minimum-stability beta; fi;
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/framework-bundle:${SYMFONY_VERSION}" --no-update; fi;
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/console:${SYMFONY_VERSION}" --no-update; fi;
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/process:${SYMFONY_VERSION}" --no-update; fi;
+
+install: composer update --prefer-dist --no-interaction $COMPOSER_FLAGS

--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,9 @@
     }
   ],
   "require": {
-    "symfony/framework-bundle": ">=2.8,<4.0",
-    "symfony/console": ">=2.8,<4.0",
-    "symfony/process": ">=2.8,<4.0",
+    "symfony/framework-bundle": ">=2.8|~3.0|^4.0",
+    "symfony/console": ">=2.8|~3.0|^4.0",
+    "symfony/process": ">=2.8|~3.0|^4.0",
     "chrisboulton/php-resque": "dev-master",
     "chrisboulton/php-resque-scheduler": "dev-master"
   },


### PR DESCRIPTION
This change adds dependencies for Symfony 4.* and expands the travis test matrix to cover multiple PHP versions and Symfony versions.

Specifically:

- Updated the `symfony/*` dependencies to `>=2.8|~3.0|^4.0`
- Updated the travis test matrix to cover PHP versions 5.6, 7.0 and 7.1 (I'm using this bundle in production under PHP 5.6)
- Updated the travis test matrix to specifically cover PHP 5.6+Symfony 2.8, PHP 5.6+Symfony3.* and PHP 7.1+Symfony4.*