### PR TITLE
Rename service from ’resque’ to ‘ResqueBundle\Resque\Resque’

### DIFF
--- a/DependencyInjection/ResqueExtension.php
+++ b/DependencyInjection/ResqueExtension.php
@@ -34,7 +34,7 @@ class ResqueExtension extends Extension
 
         if (!empty($config['prefix'])) {
             $container->setParameter('resque.prefix', $config['prefix']);
-            $container->getDefinition('resque')->addMethodCall('setPrefix', [$config['prefix']]);
+            $container->getDefinition('ResqueBundle\Resque\Resque')->addMethodCall('setPrefix', [$config['prefix']]);
         }
 
         if (!empty($config['worker']['root_dir'])) {
@@ -43,13 +43,13 @@ class ResqueExtension extends Extension
 
         if (!empty($config['auto_retry'])) {
             if (isset($config['auto_retry'][0])) {
-                $container->getDefinition('resque')->addMethodCall('setGlobalRetryStrategy', [$config['auto_retry'][0]]);
+                $container->getDefinition('ResqueBundle\Resque\Resque')->addMethodCall('setGlobalRetryStrategy', [$config['auto_retry'][0]]);
             } else {
                 if (isset($config['auto_retry']['default'])) {
-                    $container->getDefinition('resque')->addMethodCall('setGlobalRetryStrategy', [$config['auto_retry']['default']]);
+                    $container->getDefinition('ResqueBundle\Resque\Resque')->addMethodCall('setGlobalRetryStrategy', [$config['auto_retry']['default']]);
                     unset($config['auto_retry']['default']);
                 }
-                $container->getDefinition('resque')->addMethodCall('setJobRetryStrategy', [$config['auto_retry']]);
+                $container->getDefinition('ResqueBundle\Resque\Resque')->addMethodCall('setJobRetryStrategy', [$config['auto_retry']]);
             }
         }
     }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -15,7 +15,7 @@
     </parameters>
 
     <services>
-        <service id="resque" class="%resque.class%" lazy="true">
+        <service id="ResqueBundle\Resque\Resque" class="%resque.class%" lazy="true">
             <argument type="collection">
                 <argument key="kernel.root_dir">%resque.worker.root_dir%</argument>
                 <argument key="kernel.debug">%kernel.debug%</argument>


### PR DESCRIPTION
This changes the service name from a string like "resque" to a FQCN like "ResqueBundle\Resque\Resque"

The reason behind this is for Symfony 3.4+ compatibility and to silence the deprecation of using services by an alias only.

**B/C BREAK**