### PR TITLE
Change Process usage to match available versions

### DIFF
--- a/Command/StartScheduledWorkerCommand.php
+++ b/Command/StartScheduledWorkerCommand.php
@@ -110,7 +110,7 @@ class StartScheduledWorkerCommand extends ContainerAwareCommand
             $env = null;
         }
 
-        $process = new Process($workerCommand, null, $env, null, null);
+        $process = Process::fromShellCommandline($workerCommand, null, $env, null, null);
 
         $output->writeln(sprintf('Starting worker <info>%s</info>', $process->getCommandLine()));
 

--- a/Command/StartWorkerCommand.php
+++ b/Command/StartWorkerCommand.php
@@ -135,7 +135,7 @@ class StartWorkerCommand extends ContainerAwareCommand
             $env = null;
         }
 
-        $process = new Process($workerCommand, null, $env, null, null);
+        $process = Process::fromShellCommandline($workerCommand, null, $env, null, null);
 
         if (!$input->getOption('quiet')) {
             $output->writeln(sprintf('Starting worker <info>%s</info>', $process->getCommandLine()));

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "php": ">=7.1",
     "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0",
     "symfony/console": "^3.4 || ^4.0 || ^5.0",
-    "symfony/process": "^3.4 || ^4.0 || ^5.0",
+    "symfony/process": "^4.0 || ^5.0",
     "resque/php-resque": "^1.3"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "php": ">=7.1",
     "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0",
     "symfony/console": "^3.4 || ^4.0 || ^5.0",
-    "symfony/process": "^4.0 || ^5.0",
+    "symfony/process": "^4.1.2 || ^5.0",
     "resque/php-resque": "^1.3"
   },
   "require-dev": {


### PR DESCRIPTION
This should make the usage more generic for the process component but lacks support for ^3.4

#48 

For the record: I could not get it to work when passing the argument as constructor argument, I always got the same error (native os and in a docker container), then I tried this fromShellCommand and it worked directly.