### PR TITLE
Add auth to StartWorkerCommand

### DIFF
--- a/Command/StartWorkerCommand.php
+++ b/Command/StartWorkerCommand.php
@@ -97,6 +97,7 @@ class StartWorkerCommand extends Command
         $redisHost     =  $this->params->get('resque.redis.host');
         $redisPort     =  $this->params->get('resque.redis.port');
         $redisDatabase =  $this->params->get('resque.redis.database');
+        $redisPassword =  $this->params->get('resque.redis.password');
 
         if (null != $redisHost && null != $redisPort) {
             $env['REDIS_BACKEND'] = $redisHost.':'.$redisPort;
@@ -104,6 +105,10 @@ class StartWorkerCommand extends Command
 
         if (isset($redisDatabase)) {
             $env['REDIS_BACKEND_DB'] = $redisDatabase;
+        }
+
+        if (isset($redisPassword)) {
+            $env['REDIS_BACKEND_PASSWORD'] = $redisPassword;
         }
 
         $opt = '';


### PR DESCRIPTION
The PR resquebundle/resque#59 did most of the work but missed the StartWorkerCommand. This just adds redis auth to that command as well. I did this against the 5.x releases but should be trivial to backport into 4.x if that is wanted.